### PR TITLE
[Feat]: 플레이어 체력과 UI연동

### DIFF
--- a/Assets/WorkSpaces/LSH/LSH_Test_IngameHUD.unity
+++ b/Assets/WorkSpaces/LSH/LSH_Test_IngameHUD.unity
@@ -132,6 +132,7 @@ GameObject:
   m_Component:
   - component: {fileID: 48170745}
   - component: {fileID: 48170746}
+  - component: {fileID: 48170747}
   m_Layer: 5
   m_Name: Slider
   m_TagString: Untagged
@@ -158,7 +159,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -248.5, y: -175}
+  m_AnchoredPosition: {x: -235, y: -150}
   m_SizeDelta: {x: 160, y: 20}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &48170746
@@ -206,12 +207,26 @@ MonoBehaviour:
   m_HandleRect: {fileID: 0}
   m_Direction: 0
   m_MinValue: 0
-  m_MaxValue: 1
+  m_MaxValue: 100
   m_WholeNumbers: 0
-  m_Value: 1
+  m_Value: 100
   m_OnValueChanged:
     m_PersistentCalls:
       m_Calls: []
+--- !u!114 &48170747
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 48170744}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 22b61e52473549b4aae2d1607608f933, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  HpPercent: 0
+  HpFillImg: {fileID: 137763601}
 --- !u!1 &137763599
 GameObject:
   m_ObjectHideFlags: 0
@@ -507,6 +522,10 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 6907338289782665455, guid: 88eaec522f9deee4f95b5d280cc331b6, type: 3}
+      propertyPath: hp
+      value: 10
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 88eaec522f9deee4f95b5d280cc331b6, type: 3}
 --- !u!1001 &458768680
@@ -566,7 +585,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5461398710728544943, guid: c833639506c20b44bbde4eb5ed4a02f8, type: 3}
       propertyPath: healValue
-      value: 100
+      value: 25
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: c833639506c20b44bbde4eb5ed4a02f8, type: 3}

--- a/Assets/WorkSpaces/LSH/Scripts/HealPack.cs
+++ b/Assets/WorkSpaces/LSH/Scripts/HealPack.cs
@@ -14,7 +14,7 @@ public class HealPack : Collection
 
 
     // 플레이어에게 영향줄 수 있도록, 플레이어와 연결
-    [SerializeField] private PlayerModel player;
+    PlayerModel player;
     // 체력 상승수치를 직렬화
     [SerializeField] private int healValue;
 
@@ -22,7 +22,7 @@ public class HealPack : Collection
 
     private void Start()
     {
-        player = FindAnyObjectByType<PlayerModel>();
+        player = GameManager.Instance.GetPlayerModel();
 
     }
 
@@ -34,6 +34,10 @@ public class HealPack : Collection
             PickupSound();
 
             Heal();
+
+            /* Test - 체력상승 테스트를 위해 일단 줍자마자 사용됨 */ 
+            UseItem();
+
 
         }
 

--- a/Assets/WorkSpaces/LSH/Scripts/PlayerHpBar.cs
+++ b/Assets/WorkSpaces/LSH/Scripts/PlayerHpBar.cs
@@ -1,3 +1,4 @@
+using Michsky.UI.Dark;
 using System.Collections;
 using System.Collections.Generic;
 using Unity.VisualScripting;
@@ -10,20 +11,19 @@ using UnityEngine.UI;
 public class PlayerHpBar : MonoBehaviour
 {
 
+    PlayerModel player; //현재체력
 
-    PlayerModel player;
-
-    float playerHpPercent;
-
-    Image playerHpImg;
+    float playerHpPercent; //퍼센트
+    Image playerHpImg; //이미지
 
     private void Awake()
     {
-
+        
     }
 
     private void Start()
     {
+        player = GameManager.Instance.GetPlayerModel();
         player.OnHpChange += ViewHp;
     }
 
@@ -31,8 +31,9 @@ public class PlayerHpBar : MonoBehaviour
 
     protected void ViewHp()
     {
-        playerHpPercent = (player.Hp / player.Hp);
-        player.OnHpChange -= ViewHp;
+
+        playerHpPercent = (player.Hp / player.Hp/*이후에 모델쪽 최대체력 생기면 maxHp로 바꿔주기*/);
+        
     }
 
 

--- a/Assets/WorkSpaces/LSH/Scripts/PlayerHpBar.cs
+++ b/Assets/WorkSpaces/LSH/Scripts/PlayerHpBar.cs
@@ -13,28 +13,61 @@ public class PlayerHpBar : MonoBehaviour
 
     PlayerModel player; //현재체력
 
-    float playerHpPercent; //퍼센트
-    Image playerHpImg; //이미지
+    private Slider slider;
+    [SerializeField] private int HpPercent; //체력바 퍼센트
+    [SerializeField] private Image HpFillImg; //체력바 색상
 
     private void Awake()
     {
-        
+        slider = GetComponent<Slider>();
     }
 
     private void Start()
     {
         player = GameManager.Instance.GetPlayerModel();
-        player.OnHpChange += ViewHp;
+        HpBarColor();
+        player.OnHpChange += HpBarColor;
     }
 
 
 
-    protected void ViewHp()
+    
+
+    protected void HpBarColor()
+    {
+        ViewGraph();
+
+        //if (true/* "느려져 버프" 해당될 경우 */)
+        //{
+        //    Debug.Log(3);
+        //    HpFillImg.color = Color.blue;
+        //    //속도도 느려짐
+
+        //}
+        //else
+        //{
+            if (HpPercent >= 40.0f) //체력 40퍼 이상일때
+            {
+                HpFillImg.color = Color.green;
+                //속도 정상임
+            }
+            else if(HpPercent < 40.0f)// 체력 40퍼 미만일때
+            {
+                HpFillImg.color = Color.red;
+                //속도도 느려짐
+
+            }
+        //}
+
+        
+
+    }
+
+    protected void ViewGraph()
     {
 
-        playerHpPercent = (player.Hp / player.Hp/*이후에 모델쪽 최대체력 생기면 maxHp로 바꿔주기*/);
-        
+        HpPercent = player.Hp/*이후 모델쪽에 최대체력 생기면 Hp를 maxHp로 바꿔주기 or MaxValue를 건드리기*/;
+        slider.value = HpPercent;
     }
-
 
 }


### PR DESCRIPTION
- 플레이어 체력이 인게임 왼쪽 하단에 UHD로 출력되게 구현
- 플레이어 체력과 체력바 연동 (체력 수치에 변경이 생길때마다 UI에 반영)
- 힐팩아이템을 수정 (충돌시 실제로 체력에 상승값 적용했습니다.)
- 힐팩아이템 테스트를 위해 일시적으로 충돌 즉시 +25 되도록 바꿔둔 상태입니다.