### PR TITLE
[Fix]: 한 몬스터에 RigidBody가 의도치 않게 2개 존재하는 문제 수정

### DIFF
--- a/Assets/WorkSpaces/CJS/LoadTestLevel.unity
+++ b/Assets/WorkSpaces/CJS/LoadTestLevel.unity
@@ -252,6 +252,63 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 3454ff52aa464f542bb9efc9b6391872, type: 3}
+--- !u!1001 &455579400
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 8450804305950685866, guid: 838b8dbde682b814dabdbb263ab0bb16, type: 3}
+      propertyPath: m_RootOrder
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 8450804305950685866, guid: 838b8dbde682b814dabdbb263ab0bb16, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 26.832642
+      objectReference: {fileID: 0}
+    - target: {fileID: 8450804305950685866, guid: 838b8dbde682b814dabdbb263ab0bb16, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8450804305950685866, guid: 838b8dbde682b814dabdbb263ab0bb16, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 20.960493
+      objectReference: {fileID: 0}
+    - target: {fileID: 8450804305950685866, guid: 838b8dbde682b814dabdbb263ab0bb16, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8450804305950685866, guid: 838b8dbde682b814dabdbb263ab0bb16, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8450804305950685866, guid: 838b8dbde682b814dabdbb263ab0bb16, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8450804305950685866, guid: 838b8dbde682b814dabdbb263ab0bb16, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8450804305950685866, guid: 838b8dbde682b814dabdbb263ab0bb16, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8450804305950685866, guid: 838b8dbde682b814dabdbb263ab0bb16, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8450804305950685866, guid: 838b8dbde682b814dabdbb263ab0bb16, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8453821858244195410, guid: 838b8dbde682b814dabdbb263ab0bb16, type: 3}
+      propertyPath: m_Name
+      value: Scavenger
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 838b8dbde682b814dabdbb263ab0bb16, type: 3}
 --- !u!1001 &511317992
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/WorkSpaces/CJS/LoadTestMap.unity
+++ b/Assets/WorkSpaces/CJS/LoadTestMap.unity
@@ -11655,7 +11655,7 @@ Transform:
   - {fileID: 1270744314}
   - {fileID: 911077432}
   m_Father: {fileID: 0}
-  m_RootOrder: 1
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &975051047
 PrefabInstance:
@@ -13848,7 +13848,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 400004, guid: 66efbdba25775854a96fa31f4e19368f, type: 3}
       propertyPath: m_RootOrder
-      value: 2
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 400004, guid: 66efbdba25775854a96fa31f4e19368f, type: 3}
       propertyPath: m_LocalPosition.x

--- a/Assets/WorkSpaces/CJS/StageSceneManager.cs
+++ b/Assets/WorkSpaces/CJS/StageSceneManager.cs
@@ -89,8 +89,9 @@ public class StageSceneManager : MonoBehaviour
     {
         PlayerData playerData = GameManager.Instance.GetPlayerData();
 
-        // 클리어 카운트 증가
+        // 클리어 카운트 증가 및 최근 임무 성공 여부 기록
         playerData.stageClearCntArr[stageDataTable.StageIndex]++;
+        playerData.isStageCleared = true;
 
         // 수집품 획득 처리
         if (HasJournal)

--- a/Assets/WorkSpaces/HGH/PrefabsMonster/Scavenger.prefab
+++ b/Assets/WorkSpaces/HGH/PrefabsMonster/Scavenger.prefab
@@ -464,6 +464,7 @@ PrefabInstance:
     m_RemovedComponents:
     - {fileID: 5180062214429935757, guid: 7fd8c2ea11339c0429e03055ae75b37b, type: 3}
     - {fileID: 1390019740986462771, guid: 7fd8c2ea11339c0429e03055ae75b37b, type: 3}
+    - {fileID: 8805496278214220935, guid: 7fd8c2ea11339c0429e03055ae75b37b, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: 7fd8c2ea11339c0429e03055ae75b37b, type: 3}
 --- !u!4 &5669498868998637085 stripped
 Transform:


### PR DESCRIPTION
수류탄이 정상적으로 스케빈저 몬스터를 공격합니다